### PR TITLE
Bring this repo back from the dead

### DIFF
--- a/.github/workflows/docker-multiarch-publish.yml
+++ b/.github/workflows/docker-multiarch-publish.yml
@@ -38,4 +38,4 @@ jobs:
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:openjdk17
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:openjdk21

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # JRE base
-FROM openjdk:17-slim
+FROM openjdk:21-slim
 
 # Environment variables
 ENV MC_VERSION="latest" \

--- a/papermc.sh
+++ b/papermc.sh
@@ -19,7 +19,7 @@ then
 fi
 
 # Get version information and build download URL and jar name
-URL=https://papermc.io/api/v2/projects/paper
+URL=https://api.papermc.io/v2/projects/paper
 if [ ${MC_VERSION} = latest ]
 then
   # Get the latest MC version


### PR DESCRIPTION
moved from jdk17 to jdk21 for compatibility with GLIBC >2.3.1 and changed papermc api endpoint. this allows it to work for more modern setups. 

